### PR TITLE
06/15 아이템 동적 초기화 구조 수정: 콜리전 컴포넌트를 루트로

### DIFF
--- a/Source/ARPG/Private/Item/ItemActor/NAItemActor.cpp
+++ b/Source/ARPG/Private/Item/ItemActor/NAItemActor.cpp
@@ -12,40 +12,53 @@
 ANAItemActor::ANAItemActor(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)
 {
-	RootComponent = CreateDefaultSubobject<USceneComponent>(TEXT("SceneRoot"));
+	ItemCollision = CreateOptionalDefaultSubobject<USphereComponent>(TEXT("ItemCollision(Sphere)"));
+	ItemMesh = CreateOptionalDefaultSubobject<UStaticMeshComponent>(TEXT("ItemMesh(Static)"));
+
+	if (ItemCollision)
+	{
+		bWasItemCollisionCreated = true;
+	}
+	if (ItemMesh)
+	{
+		bWasItemMeshCreated = true;
+	}
 	
 	TriggerSphere = CreateDefaultSubobject<USphereComponent>("TriggerSphere");
-	TriggerSphere->SetupAttachment(RootComponent);
 	TriggerSphere->SetSphereRadius(180.0f);
 	TriggerSphere->SetCollisionEnabled(ECollisionEnabled::QueryOnly);
 	TriggerSphere->SetCollisionResponseToAllChannels(ECR_Ignore);
 	TriggerSphere->CanCharacterStepUpOn = ECB_No;
-	TriggerSphere->SetCollisionResponseToChannel(ECC_Pawn, ECollisionResponse::ECR_Overlap); 
-	
-	ItemCollision = CreateOptionalDefaultSubobject<USphereComponent>(TEXT("ItemCollision(Sphere)"));
-	ItemMesh = CreateOptionalDefaultSubobject<UStaticMeshComponent>(TEXT("ItemMesh(Static)"));
-	if (ItemCollision)
-	{
-		bUseItemCollision = true;
-	}
-	if (ItemMesh)
-	{
-		bUseItemMesh = true;
-	}
+	TriggerSphere->SetCollisionResponseToChannel(ECC_Pawn, ECollisionResponse::ECR_Overlap);
 	
 	ItemWidgetComponent = CreateDefaultSubobject<UNAItemWidgetComponent>(TEXT("ItemWidgetComponent"));
-	ItemWidgetComponent->SetupAttachment(RootComponent);
 	static ConstructorHelpers::FObjectFinder<UMaterialInterface>
 		ItemWidgetMaterial(TEXT(
 			"/Script/Engine.MaterialInstanceConstant'/Engine/EngineMaterials/Widget3DPassThrough_Translucent.Widget3DPassThrough_Translucent'"));
 	check(ItemWidgetMaterial.Object);
 	ItemWidgetComponent->SetMaterial(0, ItemWidgetMaterial.Object);
+
+	if (bWasItemCollisionCreated)
+	{
+		SetRootComponent(ItemCollision);
+		TriggerSphere->SetupAttachment(ItemCollision);
+		ItemWidgetComponent->SetupAttachment(ItemCollision);
+		if (bWasItemMeshCreated)
+		{
+			ItemMesh->SetupAttachment(ItemCollision);
+		}
+	}
 	
 	ItemDataID = NAME_None;
 	
 	bReplicates = true;
 	AActor::SetReplicateMovement( true );
 	bAlwaysRelevant = true;
+}
+
+void ANAItemActor::PostInitProperties()
+{
+	Super::PostInitProperties();
 }
 
 #if WITH_EDITOR
@@ -81,6 +94,7 @@ void ANAItemActor::OnConstruction(const FTransform& Transform)
 	const FNAItemBaseTableRow* MetaData = UNAItemEngineSubsystem::Get()->GetItemMetaDataByClass(GetClass());
 	if (!MetaData) { return; }
 	
+	const FTransform CachedRootTransform = GetRootComponent()->GetComponentTransform();
 	EItemSubobjDirtyFlags DirtyFlags = CheckDirtySubobjectFlags(MetaData);
 	
 	if (DirtyFlags != EItemSubobjDirtyFlags::ISDF_None)
@@ -154,6 +168,29 @@ void ANAItemActor::OnConstruction(const FTransform& Transform)
 			OldComponents.Empty();
 		}
 	}
+
+	// 어태치먼트
+	if (ItemCollision && ItemCollision != GetRootComponent())
+	{
+		if (GetRootComponent())
+		{
+			GetRootComponent()->DestroyComponent();
+			RemoveInstanceComponent(GetRootComponent());
+		}
+		SetRootComponent(ItemCollision);
+	}
+	if (TriggerSphere && TriggerSphere->GetAttachParent() != ItemCollision)
+	{
+		TriggerSphere->AttachToComponent(ItemCollision, FAttachmentTransformRules::KeepRelativeTransform);
+	}
+	if (ItemWidgetComponent && ItemWidgetComponent->GetAttachParent() != ItemCollision)
+	{
+		ItemWidgetComponent->AttachToComponent(ItemCollision, FAttachmentTransformRules::KeepRelativeTransform);
+	}
+	if (ItemMesh && ItemMesh->GetAttachParent() != ItemCollision)
+	{
+		ItemMesh->AttachToComponent(ItemCollision, FAttachmentTransformRules::KeepRelativeTransform);
+	}
 	
 	// 부모, 자식에서 Property로 설정된 컴포넌트들을 조회
 	TSet<UActorComponent*> SubObjsActorComponents;
@@ -180,44 +217,11 @@ void ANAItemActor::OnConstruction(const FTransform& Transform)
 				}
 				continue;
 			}
-
-			TArray<USceneComponent*> AttachedChildren = OwnedSceneComp->GetAttachChildren();
-			for (USceneComponent* Child : AttachedChildren)
-			{
-				if (IsValid(Child))
-				{
-					Child->DetachFromComponent(FDetachmentTransformRules::KeepRelativeTransform);
-				}
-			}
-			AttachedChildren.Empty();
-
+			
 			OwnedSceneComp->ClearFlags(RF_Standalone | RF_Public);
 			OwnedSceneComp->DestroyComponent();
-
-			// Actor의 Components 배열에서도 제거
-			if (AActor* MyOwner = OwnedSceneComp->GetOwner())
-			{
-				MyOwner->RemoveInstanceComponent(OwnedSceneComp);
-			}
+			RemoveInstanceComponent(OwnedSceneComp);
 		}
-	}
-	
-	// 어태치먼트
-	if (TriggerSphere && TriggerSphere->GetAttachParent() != GetRootComponent())
-	{
-		TriggerSphere->AttachToComponent(GetRootComponent(), FAttachmentTransformRules::KeepRelativeTransform);
-	}
-	if (ItemCollision && ItemCollision->GetAttachParent() != GetRootComponent())
-	{
-		ItemCollision->AttachToComponent(GetRootComponent(), FAttachmentTransformRules::KeepRelativeTransform);
-	}
-	if (ItemMesh && ItemMesh->GetAttachParent() != ItemCollision)
-	{
-		ItemMesh->AttachToComponent(ItemCollision, FAttachmentTransformRules::KeepRelativeTransform);
-	}
-	if (ItemWidgetComponent && ItemWidgetComponent->GetAttachParent() != ItemCollision)
-	{
-		ItemWidgetComponent->AttachToComponent(ItemCollision, FAttachmentTransformRules::KeepRelativeTransform);
 	}
 
 	if (MetaData->CollisionShape != EItemCollisionShape::ICS_None)
@@ -234,8 +238,6 @@ void ANAItemActor::OnConstruction(const FTransform& Transform)
 		{
 			CapsuleCollision->SetCapsuleSize(MetaData->CollisionCapsuleSize.X, MetaData->CollisionCapsuleSize.Y);
 		}
-
-		ItemCollision->SetRelativeTransform(MetaData->CollisionTransform);
 	}
 
 	if (MetaData->MeshType != EItemMeshType::IMT_None)
@@ -261,6 +263,7 @@ void ANAItemActor::OnConstruction(const FTransform& Transform)
 	// 트랜스폼 및 콜리전, 피직스 등등 설정 여기에
 	if (ItemCollision)
 	{
+		ItemCollision->SetWorldTransform(CachedRootTransform);
 		ItemCollision->SetCollisionEnabled(ECollisionEnabled::QueryAndPhysics);
 		ItemCollision->SetCollisionProfileName(TEXT("BlockAllDynamic"));
 	}
@@ -329,7 +332,7 @@ EItemSubobjDirtyFlags ANAItemActor::CheckDirtySubobjectFlags(const FNAItemBaseTa
 		return DirtyFlags;
 	}
 	
-	if (MetaData->CollisionShape != EItemCollisionShape::ICS_None && bUseItemCollision)
+	if (MetaData->CollisionShape != EItemCollisionShape::ICS_None && bWasItemCollisionCreated)
 	{
 		if (!ItemCollision)
 		{
@@ -367,7 +370,7 @@ EItemSubobjDirtyFlags ANAItemActor::CheckDirtySubobjectFlags(const FNAItemBaseTa
 		}
 	}
 	
-	if (MetaData->MeshType != EItemMeshType::IMT_None && bUseItemMesh)
+	if (MetaData->MeshType != EItemMeshType::IMT_None && bWasItemMeshCreated)
 	{
 		if (!ItemMesh)
 		{
@@ -431,6 +434,61 @@ void ANAItemActor::VerifyInteractableData()
 
 void ANAItemActor::BeginPlay()
 {
+	// 어태치먼트
+	if (ItemCollision && ItemCollision != GetRootComponent())
+	{
+		if (GetRootComponent())
+		{
+			GetRootComponent()->DestroyComponent();
+			RemoveInstanceComponent(GetRootComponent());
+		}
+		SetRootComponent(ItemCollision);
+	}
+	if (TriggerSphere && TriggerSphere->GetAttachParent() != ItemCollision)
+	{
+		TriggerSphere->AttachToComponent(ItemCollision, FAttachmentTransformRules::KeepRelativeTransform);
+	}
+	if (ItemMesh && ItemMesh->GetAttachParent() != ItemCollision)
+	{
+		ItemMesh->AttachToComponent(ItemCollision, FAttachmentTransformRules::KeepRelativeTransform);
+	}
+	if (ItemWidgetComponent && ItemWidgetComponent->GetAttachParent() != ItemCollision)
+	{
+		ItemWidgetComponent->AttachToComponent(ItemCollision, FAttachmentTransformRules::KeepRelativeTransform);
+	}
+	
+	// 부모, 자식에서 Property로 설정된 컴포넌트들을 조회
+	TSet<UActorComponent*> SubObjsActorComponents;
+	for ( TFieldIterator<FObjectProperty> It ( GetClass() ); It; ++It )
+	{
+		if ( It->PropertyClass->IsChildOf( UActorComponent::StaticClass() ) )
+		{
+			if ( UActorComponent* Component = Cast<UActorComponent>( It->GetObjectPropertyValue_InContainer( this ) ) )
+			{
+				SubObjsActorComponents.Add( Component );
+			}
+		}
+	}
+	
+	for (UActorComponent* OwnedComponent : GetComponents().Array())
+	{
+		if (USceneComponent* OwnedSceneComp = Cast<USceneComponent>(OwnedComponent))
+		{
+			if ( SubObjsActorComponents.Contains( OwnedComponent ) )
+			{
+				if (!OwnedSceneComp->IsRegistered())
+				{
+					OwnedSceneComp->RegisterComponent();
+				}
+				continue;
+			}
+
+			OwnedSceneComp->ClearFlags(RF_Standalone | RF_Public);
+			OwnedSceneComp->DestroyComponent();
+			RemoveInstanceComponent(OwnedSceneComp);
+		}
+	}
+	
 	Super::BeginPlay();
 	
 	if (Execute_CanInteract(this))
@@ -493,7 +551,6 @@ void ANAItemActor::NotifyInteractableFocusBegin_Implementation(AActor* Interacta
 		if (UNAInteractionComponent* InteractionComp = TryGetInteractionComponent(InteractorActor))
 		{
 			const bool bSucceed = InteractionComp->OnInteractableFound(this);
-			// @TODO: ANAItemActor 쪽에서 '상호작용 버튼 위젯' release?
 			if (bSucceed && ItemWidgetComponent && !ItemWidgetComponent->IsVisible())
 			{
 				ItemWidgetComponent->ReleaseItemWidgetPopup();
@@ -511,7 +568,6 @@ void ANAItemActor::NotifyInteractableFocusEnd_Implementation(AActor* Interactabl
 		if (UNAInteractionComponent* InteractionComp = TryGetInteractionComponent(InteractorActor))
 		{
 			const bool bSucceed = InteractionComp->OnInteractableLost(this);
-			// @TODO: ANAItemActor 쪽에서 '상호작용 버튼 위젯' collapse?
 			if (bSucceed && !IsPendingKillPending()
 				&& ItemWidgetComponent && ItemWidgetComponent->IsVisible())
 			{
@@ -537,7 +593,6 @@ void ANAItemActor::EndInteract_Implementation(AActor* InteractorActor)
 	{
 		bIsOnInteract = false;
 		InteractionComp->OnInteractionEnded(InteractableInterfaceRef);
-		InteractionComp->befajfl = false;
 		// @TODO: 상호작용 종료 시 필요한 로직이 있으면 여기에 추가, 상호작용 종료를 알리는 이벤트라고 생각하면 됨
 	}
 }
@@ -578,5 +633,34 @@ void ANAItemActor::DisableOverlapDuringInteraction(AActor* Interactor)
 			}
 		}
 	}
+}
+
+bool ANAItemActor::TryGetInteractableData(FNAInteractableData& OutData) const
+{
+	if (UNAItemData* ItemData = GetItemData())
+	{
+		return ItemData->GetInteractableData(OutData);
+	}
+	return false;
+}
+
+bool ANAItemActor::HasInteractionDelay() const
+{
+	FNAInteractableData Data;
+	if (GetItemData() && GetItemData()->GetInteractableData(Data))
+	{
+		return Data.InteractionDelayTime > 0.f;
+	}
+	return false;
+}
+
+float ANAItemActor::GetInteractionDelay() const
+{
+	FNAInteractableData Data;
+	if (GetItemData() && GetItemData()->GetInteractableData(Data))
+	{
+		return Data.InteractionDelayTime;
+	}
+	return 0.f;
 }
 

--- a/Source/ARPG/Private/Item/ItemActor/NAPlaceableItemActor.cpp
+++ b/Source/ARPG/Private/Item/ItemActor/NAPlaceableItemActor.cpp
@@ -4,7 +4,7 @@ ANAPlaceableItemActor::ANAPlaceableItemActor(const FObjectInitializer& ObjectIni
 	:Super(ObjectInitializer
 		.DoNotCreateDefaultSubobject(TEXT("ItemMesh(Static)")))
 {
-	bUseItemMesh = false;
+	bWasItemMeshCreated = false;
 }
 
 void ANAPlaceableItemActor::PostInitProperties()

--- a/Source/ARPG/Private/Item/PlaceableItem/Door/NAPlaceableItemActor_Door.cpp
+++ b/Source/ARPG/Private/Item/PlaceableItem/Door/NAPlaceableItemActor_Door.cpp
@@ -19,8 +19,12 @@ ANAPlaceableItemActor_Door::ANAPlaceableItemActor_Door(const FObjectInitializer&
 	ItemCollision = CreateOptionalDefaultSubobject<UBoxComponent>(TEXT("ItemCollision(Box)"));
 	if (ItemCollision)
 	{
-		bUseItemCollision = true;
-		ItemCollision->SetupAttachment(RootComponent);
+		bWasItemCollisionCreated = true;
+		SetRootComponent(ItemCollision);
+		if (TriggerSphere)
+		{
+			TriggerSphere->SetupAttachment(ItemCollision);
+		}
 		if (ItemWidgetComponent)
 		{
 			ItemWidgetComponent->SetupAttachment(ItemCollision);

--- a/Source/ARPG/Public/Item/ItemActor/NAItemActor.h
+++ b/Source/ARPG/Public/Item/ItemActor/NAItemActor.h
@@ -28,6 +28,7 @@ class ARPG_API ANAItemActor : public AActor, public INAInteractableInterface, pu
 	friend class UNAItemEngineSubsystem;
 public:
 	ANAItemActor(const FObjectInitializer& ObjectInitializer);
+	virtual void PostInitProperties() override;
 	virtual void OnConstruction(const FTransform& Transform) override;
 
 	virtual void PostLoad() override;
@@ -86,17 +87,14 @@ private:
 	void VerifyInteractableData();
 
 protected:
-	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category="Item Actor | Trigger Sphere")
-	TObjectPtr<class USphereComponent> TriggerSphere;
-
 	// Optional Subobject
-	uint8 bUseItemCollision :1 = false;
-	UPROPERTY(Instanced, VisibleAnywhere, BlueprintReadOnly, Category="Item Actor | Collision Shape")
+	uint8 bWasItemCollisionCreated :1 = false;
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category="Item Actor | Collision Shape")
 	TObjectPtr<UShapeComponent> ItemCollision;
 
 	// Optional Subobject
-	uint8 bUseItemMesh :1 = false;
-	UPROPERTY(Instanced, VisibleAnywhere, Category = "Item Actor | Mesh")
+	uint8 bWasItemMeshCreated :1 = false;
+	UPROPERTY(VisibleAnywhere, Category = "Item Actor | Mesh")
 	TObjectPtr<UMeshComponent> ItemMesh;
 
 	UPROPERTY(VisibleAnywhere, Category = "Item Actor | Static Mesh")
@@ -104,6 +102,9 @@ protected:
 	
 	UPROPERTY(VisibleAnywhere, Category = "Item Actor | Static Mesh")
 	TObjectPtr<class UGeometryCollectionCache> ItemFractureCache;
+	
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category="Item Actor | Trigger Sphere")
+	TObjectPtr<class USphereComponent> TriggerSphere;
 
 	UPROPERTY(VisibleAnywhere, Category = "Item Actor | Static Mesh")
 	TObjectPtr<class UNAItemWidgetComponent> ItemWidgetComponent;
@@ -117,7 +118,6 @@ private:
 //======================================================================================================================
 public:
 	virtual bool CanInteract_Implementation() const override;
-	//virtual bool CanInteract_Implementation() const override;
 	virtual void NotifyInteractableFocusBegin_Implementation(AActor* InteractableActor, AActor* InteractorActor) override;
 	virtual void NotifyInteractableFocusEnd_Implementation(AActor* InteractableActor, AActor* InteractorActor) override;
 
@@ -128,10 +128,18 @@ public:
 	virtual bool IsOnInteract_Implementation() const override;
 	
 	virtual void DisableOverlapDuringInteraction(AActor* Interactor) override;
+	virtual bool TryGetInteractableData(FNAInteractableData& OutData) const override final;
+	virtual bool HasInteractionDelay() const override final;
+	virtual float GetInteractionDelay() const override final;
+	virtual TScriptInterface<INAInteractableInterface> GetInteractableInterface() const override final
+	{
+		return InteractableInterfaceRef;
+	}
 
 protected:
 	/** 자기 자신(this)이 구현한 인터페이스를 보관 */
 	UPROPERTY()
 	TScriptInterface<INAInteractableInterface> InteractableInterfaceRef = nullptr;
 };
+
 


### PR DESCRIPTION
버그 있음: OnConstruction 때 Trigger Sphere하고 ItemWidgetComponent 트랜스폼 설정이 자꾸 이상한 곳으로 튐. AttachToComponent(ItemCollision, KeepRelativeTransfrom)으로 어태치먼트 변경할때, attach parent가 없어서 relative transform이 기대하지 않은 값으로 변환되는 듯 함. 기본 생성자에서 어태치먼트 설정해줘도 OnConstruction 단계만 가면 어태치 부모 없어져 있음